### PR TITLE
Fix delete function

### DIFF
--- a/src/abra/AFApiClient.ts
+++ b/src/abra/AFApiClient.ts
@@ -406,7 +406,7 @@ export class AFApiClient {
     try {
       const raw = await this._fetch(url, {
         signal: options.abortController?.signal,
-        method: 'DELTE'
+        method: 'DELETE'
       })
 
       if (raw.status >= 400 && raw.status < 600) {


### PR DESCRIPTION
The function to delete an entity in Abra is currently not working, as there is a typo `DELTE` instead of `DELETE`.