### PR TITLE
Multiple improvements

### DIFF
--- a/generator/generator.ts
+++ b/generator/generator.ts
@@ -365,7 +365,7 @@ function generateType(def: PropertyDef, forItem?: boolean): string {
     case PropertyType.Logic: return 'boolean'
     case PropertyType.Date: return 'Date'
     case PropertyType.DateTime: return 'Date'
-    case PropertyType.Blob: return 'Buffer'
+    case PropertyType.Blob: return 'Uint8Array'
     case PropertyType.YearMonth: return 'Date'
     case PropertyType.Relation: return def.tsClassName || 'any'
     case PropertyType.Select: return def.enumName || 'any'

--- a/src/abra/AFApiClient.ts
+++ b/src/abra/AFApiClient.ts
@@ -21,6 +21,8 @@ import { EntityByName, EntityByPath } from "../generated/AFEntityRegistry.js"
 import { addParamToUrl } from "../helpers/urlHelper.js"
 import { composeDetail, composeIncludes, composeRelations } from "./AFApiUrlHelper.js"
 import { AFStitkyCache } from "./AFStitkyCache.js"
+import { AFUzivatelskaVazba } from '../generated/entities/AFUzivatelskaVazba.js'
+import { AFPriloha } from '../generated/entities/AFPriloha.js'
 
 const ABRA_API_FORMAT = 'json'
 
@@ -56,7 +58,7 @@ export class AFApiClient {
     let furl = options.filter?.toUrlComponent()
     if (furl && !furl.length) furl = undefined
 
-    let url = this._url + '/c/' + this.company + '/' + entityPath
+    let url = this._url + '/c/' + this.company + '/' + (options.entityPathPrefix ?? '') + entityPath
     url += furl ? ('/' + furl) : ''
     url += '.' + ABRA_API_FORMAT
     url = addParamToUrl(url, 'detail', composeDetail(detail))
@@ -79,6 +81,10 @@ export class AFApiClient {
     url = addParamToUrl(url, 'ucetniObdobi', options.ucetniObdobi)
     url = addParamToUrl(url, 'koncovyMesicRok', options.koncovyMesicRok)
     url = addParamToUrl(url, 'pocetMesicu', options.pocetMesicu)
+
+    // Specific to "individualni cenik"
+    url = addParamToUrl(url, 'date', options.date)
+    url = addParamToUrl(url, 'currency', options.currency)
 
     console.log(url)
 
@@ -328,6 +334,10 @@ export class AFApiClient {
     console.log(url)
 
     console.log(data)
+
+    if (options.removeStitky) {
+      data['stitky@removeAll'] = 'true'
+    }
 
     try {
       const raw = await this._fetch(url, {
@@ -616,5 +626,9 @@ export class AFApiClient {
     // It's scalar
     if (!obj) return
     obj[key] = serializePropertyValue(annot.type, annot, val)
+
+    if (entity instanceof AFPriloha && key === 'content') {
+      obj['content@encoding'] = 'base64'
+    }
   }
 }

--- a/src/abra/AFApiClient.ts
+++ b/src/abra/AFApiClient.ts
@@ -464,7 +464,8 @@ export class AFApiClient {
       `Can't delete entity without knowing it's id.`
     )
 
-    let url = this._url + '/c/' + this.company + '/' + AFUzivatelskaVazba.EntityPath + '.' + ABRA_API_FORMAT
+    const entityPath = (entity.constructor as typeof AFEntity).EntityPath
+    let url = this._url + '/c/' + this.company + '/' + entityPath + '.' + ABRA_API_FORMAT
 
     try {
       const raw = await this._fetch(url, {
@@ -472,10 +473,10 @@ export class AFApiClient {
         method: 'PUT',
         body: JSON.stringify({
           winstrom: [{
-            [AFUzivatelskaVazba.EntityPath] : {
+            [entityPath] : {
               id: id,
             },
-            [AFUzivatelskaVazba.EntityPath + '@action']: 'delete'
+            [entityPath + '@action']: 'delete'
           }]
         })
       })

--- a/src/abra/AFApiClient.ts
+++ b/src/abra/AFApiClient.ts
@@ -450,6 +450,57 @@ export class AFApiClient {
     }
   }
 
+  public async deleteUserRelation(
+    entity: AFUzivatelskaVazba,
+    options: AFSaveOptions
+  ) {
+    if (!this.company || !this.company.length) {
+      throw new AFError(AFErrorCode.MISSING_ABRA_COMPANY, `Can't query AFApiClient without providing company path component first.`)
+    }
+
+    const id = entity?.id
+    if ((!id && typeof id !== 'number')) throw new AFError(
+      AFErrorCode.MISSING_ID,
+      `Can't delete entity without knowing it's id.`
+    )
+
+    let url = this._url + '/c/' + this.company + '/' + AFUzivatelskaVazba.EntityPath + '.' + ABRA_API_FORMAT
+
+    try {
+      const raw = await this._fetch(url, {
+        signal: options.abortController?.signal,
+        method: 'PUT',
+        body: JSON.stringify({
+          winstrom: [{
+            [AFUzivatelskaVazba.EntityPath] : {
+              id: id,
+            },
+            [AFUzivatelskaVazba.EntityPath + '@action']: 'delete'
+          }]
+        })
+      })
+
+      if (raw.status >= 400 && raw.status < 600) {
+        throw new AFError(AFErrorCode.ABRA_FLEXI_ERROR, `${raw.status} ${raw.statusText}`)
+      }
+
+      const json = await raw.json()
+      console.log(json)
+
+      const jres = json.winstrom
+      if (jres['success'] === 'true') {
+        // TODO
+      }
+
+    } catch (e) {
+      if (!(e instanceof AFError)) {
+        console.log(e)
+        e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
+      }
+      throw e
+    }
+  }
+
   private _decodeEntityObj<T extends typeof AFEntity>(entity: T, obj: any): InstanceType<T>[] {
     if (!obj) return []
 

--- a/src/abra/AFApiClient.ts
+++ b/src/abra/AFApiClient.ts
@@ -2,10 +2,10 @@ import { parsePropertyValue, serializePropertyValue } from "./AFDataType.js"
 import { AFEntity } from "./AFEntity.js"
 import { AFError, AFErrorCode } from "./AFError.js"
 import { Filter, ID } from "./AFFilter.js"
-import { 
-  AFApiConfig, 
-  AFApiFetch, 
-  PropertyType, 
+import {
+  AFApiConfig,
+  AFApiFetch,
+  PropertyType,
   AFQueryDetail,
   AFQueryOptions,
   AFURelOptions,
@@ -14,17 +14,32 @@ import {
   AFURelMinimal,
   AFSaveOptions,
   AFDeleteOptions,
+  AFActionOptions,
   StitkyCacheStrategy,
-  IdStub
+  IdStub,
+  AFLogger,
+  AFLogLevel,
+  AFResponseFormat,
+  AFFileResult,
+  AFQueryFileOptions
 } from "./AFTypes.js"
 import { EntityByName, EntityByPath } from "../generated/AFEntityRegistry.js"
 import { addParamToUrl } from "../helpers/urlHelper.js"
 import { composeDetail, composeIncludes, composeRelations } from "./AFApiUrlHelper.js"
+import { resolveNestedEntityPathPrefix } from "./AFNestedEntityResolver.js"
 import { AFStitkyCache } from "./AFStitkyCache.js"
 import { AFUzivatelskaVazba } from '../generated/entities/AFUzivatelskaVazba.js'
 import { AFPriloha } from '../generated/entities/AFPriloha.js'
 
 const ABRA_API_FORMAT = 'json'
+
+const LOG_LEVEL_RANK: Record<AFLogLevel, number> = {
+  none: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4
+}
 
 export class AFApiClient {
   private _url: string
@@ -33,10 +48,23 @@ export class AFApiClient {
 
   private _stitkyCache: AFStitkyCache
 
+  // Filtering wrapper around the configured logger. Always defined so call
+  // sites can use `this._logger.debug(...)` etc. without checking for null.
+  private _logger: AFLogger
+
   constructor(config: AFApiConfig) {
     this._url = config.url
     this._company = config.company
     this._fetch = config.fetch || fetch
+
+    // Default level depends on whether the user supplied a logger:
+    //   - logger only         → 'debug' (forward everything; user's logger filters)
+    //   - logLevel only       → wrap `console` and filter at the given level
+    //   - both                → forward levels ≤ logLevel to user's logger
+    //   - neither             → 'none' (silent)
+    const target: AFLogger = config.logger ?? console
+    const level: AFLogLevel = config.logLevel ?? (config.logger ? 'debug' : 'none')
+    this._logger = makeFilteringLogger(target, level)
 
     this._stitkyCache = new AFStitkyCache(this, config.stitkyCacheStrategy)
   }
@@ -45,22 +73,20 @@ export class AFApiClient {
   get company(): string { return this._company }
   get stitkyCacheStrategy(): StitkyCacheStrategy { return this._stitkyCache.strategy }
 
-  async queryRaw(
+  private _buildQueryUrl(
     entityPath: string,
+    format: string,
     options: AFQueryOptions
-  ): Promise<any> {
-    if (!this.company || !this.company.length) {
-      throw new AFError(AFErrorCode.MISSING_ABRA_COMPANY, `Can't query AFApiClient without providing company path component first.`)
-    }
-
+  ): string {
     const detail = options.detail || AFQueryDetail.SUMMARY
 
     let furl = options.filter?.toUrlComponent()
     if (furl && !furl.length) furl = undefined
 
-    let url = this._url + '/c/' + this.company + '/' + (options.entityPathPrefix ?? '') + entityPath
+    const pathPrefix = resolveNestedEntityPathPrefix(entityPath, options)
+    let url = this._url + '/c/' + this.company + '/' + pathPrefix + entityPath
     url += furl ? ('/' + furl) : ''
-    url += '.' + ABRA_API_FORMAT
+    url += '.' + format
     url = addParamToUrl(url, 'detail', composeDetail(detail))
     url = addParamToUrl(url, 'includes', composeIncludes(detail, entityPath))
     url = addParamToUrl(url, 'relations', composeRelations(detail))
@@ -86,47 +112,115 @@ export class AFApiClient {
     url = addParamToUrl(url, 'date', options.date)
     url = addParamToUrl(url, 'currency', options.currency)
 
-    console.log(url)
+    return url
+  }
+
+  async queryRaw(
+    entityPath: string,
+    options: AFQueryOptions = {}
+  ): Promise<any> {
+    if (!this.company || !this.company.length) {
+      throw new AFError(AFErrorCode.MISSING_ABRA_COMPANY, `Can't query AFApiClient without providing company path component first.`)
+    }
+
+    const url = this._buildQueryUrl(entityPath, ABRA_API_FORMAT, options)
+    this._logger.debug(url)
 
     try {
       const raw = await this._fetch(url, { signal: options.abortController?.signal })
 
+      const json = await raw.json().catch(() => null)
+
       if (raw.status >= 400 && raw.status < 600) {
-        throw new AFError(AFErrorCode.ABRA_FLEXI_ERROR, `${raw.status} ${raw.statusText}`)
+        const details = this._extractAbraErrors(json)
+        throw new AFError(
+          AFErrorCode.ABRA_FLEXI_ERROR,
+          `${raw.status} ${raw.statusText}${details ? ` — ${details}` : ''}`
+        )
       }
 
-      const json = await raw.json()
-      let entityObj = json.winstrom[entityPath]
+      let entityObj = json?.winstrom?.[entityPath]
 
       return entityObj
     } catch (e) {
       if (!(e instanceof AFError)) {
-        console.log(e)
+        this._logger.error(e)
         e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
       }
       throw e
     }
   }
 
+  async queryFileRaw(
+    entityPath: string,
+    format: AFResponseFormat,
+    options: AFQueryFileOptions = {}
+  ): Promise<AFFileResult> {
+    if (!this.company || !this.company.length) {
+      throw new AFError(AFErrorCode.MISSING_ABRA_COMPANY, `Can't query AFApiClient without providing company path component first.`)
+    }
+
+    let url = this._buildQueryUrl(entityPath, format, options)
+    url = addParamToUrl(url, 'report-name', options.reportName)
+    url = addParamToUrl(url, 'report-lang', options.reportLang)
+    this._logger.debug(url)
+
+    try {
+      const raw = await this._fetch(url, { signal: options.abortController?.signal })
+
+      if (raw.status >= 400 && raw.status < 600) {
+        let details = ''
+        const ct = raw.headers.get('content-type') || ''
+        if (ct.includes('application/json')) {
+          const json = await raw.json().catch(() => null)
+          details = this._extractAbraErrors(json)
+        }
+        throw new AFError(
+          AFErrorCode.ABRA_FLEXI_ERROR,
+          `${raw.status} ${raw.statusText}${details ? ` — ${details}` : ''}`
+        )
+      }
+
+      const blob = await raw.blob()
+      const contentType = raw.headers.get('content-type') || 'application/octet-stream'
+      const filename = parseContentDispositionFilename(raw.headers.get('content-disposition'))
+      return { blob, contentType, filename }
+    } catch (e) {
+      if (!(e instanceof AFError)) {
+        this._logger.error(e)
+        e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
+      }
+      throw e
+    }
+  }
+
+  public async queryFile<T extends typeof AFEntity>(
+    entity: T,
+    format: AFResponseFormat,
+    options: AFQueryFileOptions = {}
+  ): Promise<AFFileResult> {
+    return this.queryFileRaw(entity.EntityPath, format, options)
+  }
+
   public async query<T extends typeof AFEntity>(
-    entity: T, 
-    options: AFQueryOptions
+    entity: T,
+    options: AFQueryOptions = {}
   ): Promise<InstanceType<T>[]> {
     const res = this.queryRaw(entity.EntityPath, options)
 
     try {
       const rawData = await res
       const data = this._decodeEntityObj(entity, rawData)
-      
+
       if (!options.noUpdateStitkyCache) {
         await this._stitkyCache.fetchTick()
       }
-      
+
       return data
 
     } catch (e) {
       if (!(e instanceof AFError)) {
-        console.log(e)
+        this._logger.error(e)
         e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
       }
       throw e
@@ -134,7 +228,7 @@ export class AFApiClient {
   }
 
   public async queryOne<T extends typeof AFEntity>(
-    entity: T, 
+    entity: T,
     options: AFQueryOptions
   ): Promise<InstanceType<T>> {
     const data = await this.query(entity, options)
@@ -144,7 +238,7 @@ export class AFApiClient {
 
   public async queryURels<T extends typeof AFEntity = typeof AFEntity>(
     relatedEntity: T,
-    forObjects: AFURelMinimal | AFURelMinimal[], 
+    forObjects: AFURelMinimal | AFURelMinimal[],
     options: AFURelOptions = {},
   ): Promise<AFURelResult<InstanceType<T>>[]> {
     if (!(forObjects instanceof Array)) {
@@ -157,37 +251,37 @@ export class AFApiClient {
 
     const out: AFURelResult<InstanceType<T>>[] = []
     const fetchedList: [string, InstanceType<T>[]][] = []
-    
+
     for (const uobj of forObjects) {
       const uvs = uobj["uzivatelske-vazby"]
       if (!uvs) continue
       for (const uv of uvs) {
         // Check if vazba is properly defined and if it has proper vazbaTyp (if required)
         if (!uv.evidenceType || !uv.objectId) continue
-        if (options.vazbaTyp && 
-          (!uv.vazbaTyp || 
-            typeof uv.vazbaTyp.kod !== 'string' || 
-            !options.vazbaTyp.includes(uv.vazbaTyp.kod)) 
+        if (options.vazbaTyp &&
+          (!uv.vazbaTyp ||
+            typeof uv.vazbaTyp.kod !== 'string' ||
+            !options.vazbaTyp.includes(uv.vazbaTyp.kod))
         ) continue
 
         // Check if related evidence type matches the requested type
         const cls = EntityByPath(uv.evidenceType)
         if (cls !== relatedEntity) continue
-        
+
         // Get (or create) list of already fetched objects by evidenceType
         let list = fetchedList.find(fli => fli[0] === uv.evidenceType)
         if (!list) {
           list = [uv.evidenceType, []]
           fetchedList.push(list)
         }
-        
+
         // Load data from cache or fetch it if missing
         let data = list[1].find(li => li.id === uv.objectId)
         if (!data) {
           try {
-            const opts = { 
-              detail: options.detail, 
-              filter: ID(uv.objectId), 
+            const opts = {
+              detail: options.detail,
+              filter: ID(uv.objectId),
               abort: options.abortController,
               noUpdateStitkyCache: true
             }
@@ -202,7 +296,7 @@ export class AFApiClient {
             out.push(res)
           } catch (e) {
             if (!(e instanceof AFError)) {
-              console.log(e)
+              this._logger.error(e)
               e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
             }
             throw e
@@ -220,13 +314,13 @@ export class AFApiClient {
   }
 
   public async populate<T extends typeof AFEntity = typeof AFEntity>(
-    entities: InstanceType<T>[], 
-    options: AFPopulateOptions
+    entities: InstanceType<T>[],
+    options: AFPopulateOptions = {}
   ): Promise<InstanceType<T>[]> {
     const fetchBy: [string, string][] = []
     for (const en of entities) {
       if (typeof en.id !== 'undefined' && en.id !== null) {
-        fetchBy.push(['id', en.id.toString()]) 
+        fetchBy.push(['id', en.id.toString()])
         continue
       }
       if (typeof en.kod !== 'undefined') {
@@ -234,11 +328,11 @@ export class AFApiClient {
         continue
       }
       throw new AFError(
-        AFErrorCode.MISSING_ID, 
+        AFErrorCode.MISSING_ID,
         `Can't populate entity withoud id or kod set. It's not possible to fetch data. Entity: ${en}`
       )
     }
-    
+
     // Nothing was requested to populate
     if (!fetchBy.length) return []
 
@@ -254,10 +348,10 @@ export class AFApiClient {
       abortController: options.abortController
     }
 
-    try { 
+    try {
       const cls = EntityByName(entities[0].constructor.name)
       const resQRaw = this.queryRaw(cls.EntityPath, opts)
-      
+
       let dataQ = await resQRaw
       if (!dataQ) throw new AFError(AFErrorCode.UNKNOWN, 'Unable to fetch data to populate')
       if (!(dataQ instanceof Array)) dataQ = [dataQ]
@@ -269,11 +363,12 @@ export class AFApiClient {
           return false
         })
         if (!en) continue
-        
+
         const oKeys = Object.keys(enQ)
         for (const okey of oKeys) {
-          this._decodeProperty(en, okey, enQ)        
+          this._decodeProperty(en, okey, enQ)
         }
+        en._isNew = false
       }
 
       if (!options.noUpdateStitkyCache) {
@@ -281,7 +376,7 @@ export class AFApiClient {
       }
     } catch (e) {
       if (!(e instanceof AFError)) {
-        console.log(e)
+        this._logger.error(e)
         e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
       }
       throw e
@@ -291,8 +386,8 @@ export class AFApiClient {
   }
 
   public async populateOne<T extends typeof AFEntity = typeof AFEntity>(
-    entity: InstanceType<T>, 
-    options: AFPopulateOptions
+    entity: InstanceType<T>,
+    options: AFPopulateOptions = {}
   ): Promise<InstanceType<T>> {
     const res = await this.populate([entity], options)
     if (!res || !res.length) throw new AFError(AFErrorCode.OBJECT_NOT_FOUND, `${entity} object not found. Kod / ID: ${entity.kod} / ${entity.id}`)
@@ -307,7 +402,7 @@ export class AFApiClient {
 
   public async createIdStub<T extends typeof AFEntity>(
     entity: T,
-    id: IdStub 
+    id: IdStub
   ): Promise<InstanceType<T>> {
     if (typeof id.id !== 'number' && (!id.kod || !id.kod.length) && (!id.ext || !id.ext.length)) {
       throw new AFError(AFErrorCode.MISSING_ID, `Requesting id stub for ${entity.EntityName} but no id is pprovided.`)
@@ -315,6 +410,7 @@ export class AFApiClient {
     const ent = new entity(this._stitkyCache) as InstanceType<T>
     if (id.id) ent.id = id.id
     if (id.kod) ent.kod = id.kod
+    ent._isNew = false
     return ent
   }
 
@@ -331,9 +427,8 @@ export class AFApiClient {
 
     let url = this._url + '/c/' + this.company + '/' + entityPath + '.' + ABRA_API_FORMAT
 
-    console.log(url)
-
-    console.log(data)
+    this._logger.debug(url)
+    this._logger.debug(data)
 
     if (options.removeStitky) {
       data['stitky@removeAll'] = 'true'
@@ -353,22 +448,30 @@ export class AFApiClient {
         })
       })
 
+      const json = await raw.json().catch(() => null)
+      this._logger.debug(json)
+
       if (raw.status >= 400 && raw.status < 600) {
-        console.log(JSON.stringify(await raw.json(), null, '\n'))
-        throw new AFError(AFErrorCode.ABRA_FLEXI_ERROR, `${raw.status} ${raw.statusText}`)
+        const details = this._extractAbraErrors(json)
+        throw new AFError(
+          AFErrorCode.ABRA_FLEXI_ERROR,
+          `${raw.status} ${raw.statusText}${details ? ` — ${details}` : ''}`
+        )
       }
 
-      const json = await raw.json()
-      console.log(JSON.stringify(json))
-
-      const jres = json.winstrom
-      if (jres['success'] === 'true') {
-        // TODO
+      const jres = json?.winstrom
+      if (jres && jres['success'] === 'false') {
+        const details = this._extractAbraErrors(json)
+        throw new AFError(
+          AFErrorCode.ABRA_FLEXI_ERROR,
+          `Save of ${entityPath} failed${details ? ` — ${details}` : ''}`
+        )
       }
 
+      return Array.isArray(jres?.results) ? jres.results : []
     } catch (e) {
       if (!(e instanceof AFError)) {
-        console.log(e)
+        this._logger.error(e)
         e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
       }
       throw e
@@ -376,19 +479,30 @@ export class AFApiClient {
   }
 
   public async save<T extends typeof AFEntity = typeof AFEntity>(
-    entity: InstanceType<T>, 
+    entity: InstanceType<T>,
     options?: AFSaveOptions
   ): Promise<InstanceType<T>> {
+    if (entity.isNew) {
+      const uvs = (entity as any)['uzivatelske-vazby']
+      if (Array.isArray(uvs) && uvs.length > 0) {
+        throw new AFError(
+          AFErrorCode.FORBIDDEN_OPERATION,
+          `Creating ${(entity.constructor as typeof AFEntity).EntityName} with 'uzivatelske-vazby' is not supported by the API. Workaround: save the entity first without user relations, then add them in a second update (save) request.`
+        )
+      }
+    }
+
     const obj = this._encodeEntity(entity)
     const res = this.saveRaw((entity.constructor as typeof AFEntity).EntityPath, obj, options)
 
     try {
-      const rawData = await res
-
+      const results = await res
+      this._applySaveResultToEntity(entity, results)
+      entity._isNew = false
       return entity
     } catch (e) {
       if (!(e instanceof AFError)) {
-        console.log(e)
+        this._logger.error(e)
         e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
       }
       throw e
@@ -398,7 +512,7 @@ export class AFApiClient {
   async deleteRaw(
     entityPath: string,
     id: string | number | undefined | null,
-    options: AFSaveOptions
+    options: AFDeleteOptions = {}
   ): Promise<any> {
     if (!this.company || !this.company.length) {
       throw new AFError(AFErrorCode.MISSING_ABRA_COMPANY, `Can't query AFApiClient without providing company path component first.`)
@@ -409,76 +523,11 @@ export class AFApiClient {
       `Can't delete entity without knowing it's id.`
     )
 
-    let url = this._url + '/c/' + this.company + '/' + entityPath + '/' + id + '.' + ABRA_API_FORMAT
-
-    console.log(url)
-
-    try {
-      const raw = await this._fetch(url, {
-        signal: options.abortController?.signal,
-        method: 'DELETE'
-      })
-
-      if (raw.status >= 400 && raw.status < 600) {
-        throw new AFError(AFErrorCode.ABRA_FLEXI_ERROR, `${raw.status} ${raw.statusText}`)
-      }
-
-      const json = await raw.json()
-      console.log(json)
-
-      const jres = json.winstrom
-      if (jres['success'] === 'true') {
-        // TODO
-      }
-
-    } catch (e) {
-      if (!(e instanceof AFError)) {
-        console.log(e)
-        e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
-      }
-      throw e
-    }
-  }
-
-  public async delete<T extends typeof AFEntity = typeof AFEntity>(
-    entity: InstanceType<T>, 
-    options: AFDeleteOptions
-  ): Promise<boolean> {
-    if (entity.isNew) return true
-
-    const res = this.deleteRaw((entity.constructor as typeof AFEntity).EntityPath, entity.id, options)
-
-    try {
-      await res
-      return true
-    } catch (e) {
-      if (!(e instanceof AFError)) {
-        console.log(e)
-        e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
-      }
-      throw e
-    }
-  }
-
-  public async deleteUserRelation(
-    entity: AFUzivatelskaVazba,
-    options: AFSaveOptions
-  ) {
-    if (!this.company || !this.company.length) {
-      throw new AFError(AFErrorCode.MISSING_ABRA_COMPANY, `Can't query AFApiClient without providing company path component first.`)
-    }
-
-    const id = entity?.id
-    if ((!id && typeof id !== 'number')) throw new AFError(
-      AFErrorCode.MISSING_ID,
-      `Can't delete entity without knowing it's id.`
-    )
-
-    const entityPath = (entity.constructor as typeof AFEntity).EntityPath
-    let url = this._url + '/c/' + this.company + '/' + entityPath + '.' + ABRA_API_FORMAT
-
-    try {
-      const raw = await this._fetch(url, {
+    let url: string
+    let fetchOptions: any
+    if (options.asUserRelation) {
+      url = this._url + '/c/' + this.company + '/' + entityPath + '.' + ABRA_API_FORMAT
+      fetchOptions = {
         signal: options.abortController?.signal,
         method: 'PUT',
         body: JSON.stringify({
@@ -489,27 +538,230 @@ export class AFApiClient {
             [entityPath + '@action']: 'delete'
           }]
         })
-      })
+      }
+    } else {
+      url = this._url + '/c/' + this.company + '/' + entityPath + '/' + id + '.' + ABRA_API_FORMAT
+      fetchOptions = {
+        signal: options.abortController?.signal,
+        method: 'DELETE'
+      }
+    }
+
+    this._logger.debug(url)
+
+    try {
+      const raw = await this._fetch(url, fetchOptions)
+
+      const json = await raw.json().catch(() => null)
+      this._logger.debug(json)
 
       if (raw.status >= 400 && raw.status < 600) {
-        throw new AFError(AFErrorCode.ABRA_FLEXI_ERROR, `${raw.status} ${raw.statusText}`)
+        const details = this._extractAbraErrors(json)
+        throw new AFError(
+          AFErrorCode.ABRA_FLEXI_ERROR,
+          `${raw.status} ${raw.statusText}${details ? ` — ${details}` : ''}`
+        )
       }
 
-      const json = await raw.json()
-      console.log(json)
-
-      const jres = json.winstrom
-      if (jres['success'] === 'true') {
-        // TODO
+      const jres = json?.winstrom
+      if (jres && jres['success'] === 'false') {
+        const details = this._extractAbraErrors(json)
+        throw new AFError(
+          AFErrorCode.ABRA_FLEXI_ERROR,
+          `Delete of ${entityPath} failed${details ? ` — ${details}` : ''}`
+        )
       }
 
     } catch (e) {
       if (!(e instanceof AFError)) {
-        console.log(e)
+        this._logger.error(e)
         e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
       }
       throw e
     }
+  }
+
+  public async delete<T extends typeof AFEntity = typeof AFEntity>(
+    entity: InstanceType<T>,
+    options: AFDeleteOptions = {}
+  ): Promise<boolean> {
+    if (entity.isNew) return true
+
+    const entityPath = (entity.constructor as typeof AFEntity).EntityPath
+    const res = this.deleteRaw(entityPath, entity.id, {
+      ...options,
+      asUserRelation: entity instanceof AFUzivatelskaVazba
+    })
+
+    try {
+      await res
+      return true
+    } catch (e) {
+      if (!(e instanceof AFError)) {
+        this._logger.error(e)
+        e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
+      }
+      throw e
+    }
+  }
+
+  // Invokes a named action on an existing entity record. The HTTP shape mirrors
+  // the user-relation delete pattern: PUT to /entity.json with body
+  // `{ winstrom: [{ <entityPath>: { id }, "<entityPath>@action": <actionName> }] }`.
+  // Returns true on success; throws AFError on HTTP/Abra failure.
+  async callEntityActionRaw(
+    entityPath: string,
+    id: string | number,
+    actionName: string,
+    options: AFActionOptions = {}
+  ): Promise<boolean> {
+    if (!this.company || !this.company.length) {
+      throw new AFError(AFErrorCode.MISSING_ABRA_COMPANY, `Can't query AFApiClient without providing company path component first.`)
+    }
+
+    if (id === undefined || id === null || id === '') {
+      throw new AFError(AFErrorCode.MISSING_ID, `Can't call action '${actionName}' on ${entityPath} without id.`)
+    }
+
+    if (!actionName || !actionName.length) {
+      throw new AFError(AFErrorCode.UNKNOWN, `Action name must be a non-empty string.`)
+    }
+
+    const url = this._url + '/c/' + this.company + '/' + entityPath + '.' + ABRA_API_FORMAT
+    this._logger.debug(url)
+
+    try {
+      const raw = await this._fetch(url, {
+        signal: options.abortController?.signal,
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          winstrom: [{
+            [entityPath]: { id: id },
+            [entityPath + '@action']: actionName
+          }]
+        })
+      })
+
+      const json = await raw.json().catch(() => null)
+      this._logger.debug(json)
+
+      if (raw.status >= 400 && raw.status < 600) {
+        const details = this._extractAbraErrors(json)
+        throw new AFError(
+          AFErrorCode.ABRA_FLEXI_ERROR,
+          `${raw.status} ${raw.statusText}${details ? ` — ${details}` : ''}`
+        )
+      }
+
+      const jres = json?.winstrom
+      if (jres && jres['success'] === 'false') {
+        const details = this._extractAbraErrors(json)
+        throw new AFError(
+          AFErrorCode.ABRA_FLEXI_ERROR,
+          `Action '${actionName}' on ${entityPath} failed${details ? ` — ${details}` : ''}`
+        )
+      }
+
+      return true
+    } catch (e) {
+      if (!(e instanceof AFError)) {
+        this._logger.error(e)
+        e = new AFError(AFErrorCode.UNKNOWN, (e as Error).toString())
+      }
+      throw e
+    }
+  }
+
+  public async callEntityAction<T extends typeof AFEntity = typeof AFEntity>(
+    entity: InstanceType<T>,
+    actionName: string,
+    options: AFActionOptions = {}
+  ): Promise<boolean> {
+    if (entity.isNew) {
+      throw new AFError(
+        AFErrorCode.RELATED_INSTANCE_NOT_SAVED,
+        `Can't call action '${actionName}' on an unsaved ${(entity.constructor as typeof AFEntity).EntityName}. Save it first.`
+      )
+    }
+
+    if (entity.id === undefined || entity.id === null) {
+      throw new AFError(
+        AFErrorCode.MISSING_ID,
+        `Can't call action '${actionName}' on ${(entity.constructor as typeof AFEntity).EntityName} without id.`
+      )
+    }
+
+    const entityPath = (entity.constructor as typeof AFEntity).EntityPath
+    return this.callEntityActionRaw(entityPath, entity.id, actionName, options)
+  }
+
+  // Applies the server-assigned id from a save response back to the entity.
+  // Abra returns one entry per persisted record in `winstrom.results[]` —
+  // including any nested entities (e.g. attachments) created alongside the
+  // main one. Each entry has an optional `ref` of the form
+  // `/c/<company>/<entityPath>/<id>.json`, which we use to pick the correct
+  // result. (Abra does not return `kod` here, so only `id` is applied.)
+  private _applySaveResultToEntity<T extends AFEntity>(entity: T, results: any): void {
+    if (!Array.isArray(results) || !results.length) return
+
+    const entityPath = (entity.constructor as typeof AFEntity).EntityPath
+
+    // Prefer a result whose `ref` points to this entity's type.
+    let r = results.find((res: any) =>
+      res && typeof res.ref === 'string' && res.ref.includes(`/${entityPath}/`)
+    )
+
+    // Fallback for simple saves with a single result and no nested creates:
+    // Abra often omits `ref` then. Only use this when exactly one result has
+    // no `ref` and there's no ambiguity.
+    if (!r) {
+      const refless = results.filter((res: any) => res && typeof res.ref !== 'string')
+      if (refless.length === 1 && results.length === 1) r = refless[0]
+    }
+
+    if (!r || r.id === undefined || r.id === null) return
+
+    const newId = typeof r.id === 'number' ? r.id : Number(r.id)
+    if (Number.isFinite(newId)) {
+      entity.id = newId
+      entity._orig.id = newId
+    }
+  }
+
+  private _extractAbraErrors(json: any): string {
+    if (!json) return ''
+    const winstrom = json.winstrom
+    if (!winstrom) return ''
+
+    const messages: string[] = []
+
+    if (typeof winstrom.message === 'string' && winstrom.message.length) {
+      messages.push(winstrom.message)
+    }
+
+    const results = winstrom.results
+    if (Array.isArray(results)) {
+      for (const r of results) {
+        if (!r || !Array.isArray(r.errors)) continue
+        for (const err of r.errors) {
+          if (!err) continue
+          if (typeof err === 'string') {
+            messages.push(err)
+            continue
+          }
+          const parts: string[] = []
+          if (err.code) parts.push(`[${err.code}]`)
+          if (err.for) parts.push(`(${err.for})`)
+          if (err.message) parts.push(err.message)
+          if (parts.length) messages.push(parts.join(' '))
+        }
+      }
+    }
+
+    return messages.join('; ')
   }
 
   private _decodeEntityObj<T extends typeof AFEntity>(entity: T, obj: any): InstanceType<T>[] {
@@ -532,8 +784,9 @@ export class AFApiClient {
       const ent = new entity(this._stitkyCache) as InstanceType<T>
       const oKeys = Object.keys(o)
       for (const okey of oKeys) {
-        this._decodeProperty(ent, okey, o)        
+        this._decodeProperty(ent, okey, o)
       }
+      ent._isNew = false
       res.push(ent)
     }
     return res
@@ -557,7 +810,7 @@ export class AFApiClient {
 
     // If it's relation, recursively call _processEntityObj
     if (annot.type === PropertyType.Relation) {
-      if (!annot.afClass) return 
+      if (!annot.afClass) return
       const cls = typeof annot.afClass === 'string' ? EntityByName(annot.afClass) : annot.afClass
       const propOut = this._decodeEntityObj(cls, v)
       if (!propOut) return
@@ -614,7 +867,7 @@ export class AFApiClient {
       }
       if (!(val instanceof AFEntity)) throw new AFError(AFErrorCode.UNKNOWN, `Key '${key}' on ${(entity.constructor as typeof AFEntity).EntityName}(id: ${entity.id}) referencing not AFEntity instance`)
       // Check if related object has ID, if no - throw
-      if (val.isNew) throw new AFError(AFErrorCode.RELATED_INSTANCE_NOT_SAVED, `Key '${key}' on ${(entity.constructor as typeof AFEntity).EntityName}(id: ${entity.id}) referencing not saved (new) instance - missing 'id' in it`)
+      if (val.isNew) throw new AFError(AFErrorCode.RELATED_INSTANCE_NOT_SAVED, `Key '${key}' on ${(entity.constructor as typeof AFEntity).EntityName}(id: ${entity.id}) references an unsaved instance. Save it first, or use createIdStub() to reference an existing entity by id/kod.`)
       if (typeof val.id === 'undefined') {
         obj[key] = `code:${val.kod}`
       } else {
@@ -631,4 +884,33 @@ export class AFApiClient {
       obj['content@encoding'] = 'base64'
     }
   }
+}
+
+// Wraps a logger with level-based filtering. The result conforms to AFLogger
+// and can be called as `logger.debug(...)`, `logger.error(...)`, etc.
+// Methods at levels above the threshold become no-ops.
+function makeFilteringLogger(target: AFLogger, level: AFLogLevel): AFLogger {
+  const threshold = LOG_LEVEL_RANK[level]
+  const make = (lvl: Exclude<AFLogLevel, 'none'>): (...args: any[]) => void => {
+    if (LOG_LEVEL_RANK[lvl] > threshold) return () => {}
+    return (...args: any[]) => target[lvl](...args)
+  }
+  return {
+    debug: make('debug'),
+    info: make('info'),
+    warn: make('warn'),
+    error: make('error')
+  }
+}
+
+function parseContentDispositionFilename(header: string | null): string | undefined {
+  if (!header) return undefined
+  // Try RFC 5987 form first (filename*=UTF-8''…) then plain filename="…" / filename=…
+  const ext = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(header)
+  if (ext) {
+    try { return decodeURIComponent(ext[1].trim().replace(/^"|"$/g, '')) } catch { /* fall through */ }
+  }
+  const plain = /filename=("([^"]+)"|([^;]+))/i.exec(header)
+  if (plain) return (plain[2] ?? plain[3] ?? '').trim()
+  return undefined
 }

--- a/src/abra/AFDataType.ts
+++ b/src/abra/AFDataType.ts
@@ -10,7 +10,7 @@ type PropertyTypeMap = {
   [PropertyType.Date]: Date;
   [PropertyType.Numeric]: Big;
   [PropertyType.Logic]: boolean;
-  [PropertyType.Blob]: Buffer;
+  [PropertyType.Blob]: Uint8Array;
   [PropertyType.Array]: any[]; // Must be inferred from typeAnnotation
 }
 
@@ -56,7 +56,7 @@ export function parsePropertyValue<T extends PropertyType>(
       return (obj.toLowerCase() === "true") as ParsedType<T>;
 
     case PropertyType.Blob:
-      return Buffer.from(obj, "base64") as ParsedType<T>;
+      return base64ToBytes(obj) as ParsedType<T>;
 
     case PropertyType.Array:
       if (!annot?.itemType) throw new AFError(AFErrorCode.ITEM_TYPE_MISSING, "itemType is required for Array");
@@ -106,7 +106,7 @@ export function serializePropertyValue<T extends PropertyType>(
       return !!val ? "true" : "false"
 
     case PropertyType.Blob:
-      return val.toString('base64')
+      return bytesToBase64(val as Uint8Array)
 
     case PropertyType.Array:
       if (!annot?.itemType) throw new AFError(AFErrorCode.ITEM_TYPE_MISSING, "itemType is required for Array");
@@ -144,6 +144,30 @@ function dateToLocalIso(date: Date): string {
   const om = pad(Math.abs(offset) % 60)
 
   return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}.${ms}${sign}${oh}:${om}`
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    const buf = Buffer.from(base64, 'base64')
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+  }
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64')
+  }
+  let binary = ''
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
 }
 
 export function arraysEqual<T>(a: T[], b: T[]): boolean {

--- a/src/abra/AFEntity.ts
+++ b/src/abra/AFEntity.ts
@@ -18,6 +18,11 @@ export class AFEntity {
   stitky?: string | null
 
   _orig: Record<string, any> = {}
+  // True until the entity is confirmed to exist in Abra. Cleared by AFApiClient
+  // when the entity is decoded from a server response, returned from
+  // createIdStub(), or successfully saved. Setting `id` or `kod` manually does
+  // NOT clear this — use createIdStub() for referencing existing entities.
+  _isNew: boolean = true
 
   constructor(stitkyCache: AFStitkyCache) {
     this._stitkyCache = stitkyCache
@@ -40,7 +45,7 @@ export class AFEntity {
   }
 
   get isNew(): boolean {
-    return !this.id && !this.kod
+    return this._isNew
   }
 
   protected getCotr(): typeof AFEntity {

--- a/src/abra/AFNestedEntityResolver.ts
+++ b/src/abra/AFNestedEntityResolver.ts
@@ -1,0 +1,56 @@
+import { AFQueryOptions } from './AFTypes.js'
+import { AFFilter } from './AFFilter.js'
+import { AFError, AFErrorCode } from './AFError.js'
+
+// Resolves the URL path prefix needed to scope a query to a parent entity.
+// E.g. `individualni-cenik` of a given firma lives under `adresar/<id>/individualni-cenik`.
+// Returns '' (empty prefix) when the entity is queried at top level.
+//
+// To support a new nested entity, add a case below that reads the
+// entity-specific selector(s) from `AFQueryOptions` and returns the prefix
+// (must end with '/').
+export function resolveNestedEntityPathPrefix(
+  entityPath: string,
+  options: AFQueryOptions
+): string {
+  switch (entityPath) {
+    case 'individualni-cenik': {
+      const sel = serializeParentSelector(options.adresarId, 'adresarId', entityPath)
+      if (sel === undefined) return ''
+      return `adresar/${sel}/`
+    }
+    default:
+      return ''
+  }
+}
+
+// Converts a parent selector (numeric id, id-as-string, or AFFilter from
+// ID()/CODE()/EXT()) into the URL path component Abra expects.
+// Returns undefined when the selector is not provided.
+function serializeParentSelector(
+  value: number | string | AFFilter | undefined | null,
+  optionName: string,
+  entityPath: string
+): string | undefined {
+  if (value === undefined || value === null) return undefined
+
+  if (value instanceof AFFilter) {
+    const piece = value.toUrlComponent()
+    if (!piece.length) {
+      throw new AFError(
+        AFErrorCode.MISSING_ID,
+        `'${optionName}' for ${entityPath} resolved to empty URL component.`
+      )
+    }
+    return piece
+  }
+
+  if (typeof value === 'string' && !value.length) {
+    throw new AFError(
+      AFErrorCode.MISSING_ID,
+      `'${optionName}' for ${entityPath} must be a non-empty id.`
+    )
+  }
+
+  return String(value)
+}

--- a/src/abra/AFStitkyCache.ts
+++ b/src/abra/AFStitkyCache.ts
@@ -4,7 +4,7 @@ import { AFQueryDetail, AFQueryOptions, NO_LIMIT, StitkyCacheStrategy } from './
 import type { AFApiClient } from './AFApiClient.js'
 import { Filter } from './AFFilter.js'
 
-const DEBOUNCE_MS = 5 * 1000 // 10 sec
+const DEBOUNCE_MS = 5 * 1000 // 5 sec
 
 export class AFStitkyCache {
   private _client: AFApiClient
@@ -13,6 +13,7 @@ export class AFStitkyCache {
   private _stitekSkupiny: AFSkupinaStitku[] = []
 
   private _lastUpdate?: Date
+  private _inflight?: Promise<void>
 
   constructor(client: AFApiClient, strategy?: StitkyCacheStrategy) {
     this._client = client
@@ -31,44 +32,58 @@ export class AFStitkyCache {
     const now = new Date()
     if (this._lastUpdate && now.getTime() - this._lastUpdate.getTime() < DEBOUNCE_MS) return
 
-    const skupOpts: AFQueryOptions = {
-      limit: NO_LIMIT,
-      detail: AFQueryDetail.FULL,
-      noUpdateStitkyCache: true, // IMPORTANT! Otherwise possible recurrence cycle
-    }
-    if (this._lastUpdate) {
-      skupOpts.filter = Filter(`lastUpdate > ':date'`, { date: this._lastUpdate })
-    }
-    const skUpdate = await this._client.query(AFSkupinaStitku, skupOpts)
+    if (this._inflight) return this._inflight
 
-    for (const sk of skUpdate) {
-      let found = this._stitekSkupiny.find(ss => ss.id === sk.id)
-      if (!found) {
-        this._stitekSkupiny.push(sk)
-        continue
+    this._inflight = (async () => {
+      try {
+        const sinceTs = this._lastUpdate ? formatAbraTimestamp(this._lastUpdate) : undefined
+
+        const skupOpts: AFQueryOptions = {
+          limit: NO_LIMIT,
+          detail: AFQueryDetail.FULL,
+          noUpdateStitkyCache: true, // IMPORTANT! Otherwise possible recurrence cycle
+        }
+        if (sinceTs) {
+          skupOpts.filter = Filter(`lastUpdate > :date`, { date: sinceTs })
+        }
+        const skUpdate = await this._client.query(AFSkupinaStitku, skupOpts)
+
+        for (const sk of skUpdate) {
+          let found = this._stitekSkupiny.find(ss => ss.id === sk.id)
+          if (!found) {
+            this._stitekSkupiny.push(sk)
+            continue
+          }
+          Object.assign(found, sk)
+        }
+
+        const stitOpts: AFQueryOptions = {
+          limit: NO_LIMIT,
+          detail: ['id', 'kod', 'lastUpdate', 'nazev', 'nazevA', 'nazevB', 'nazevC', 'nazevD', 'poznam', 'popis', 'platiOd', 'platiDo', 'skupVybKlic'],
+          noUpdateStitkyCache: true, // IMPORTANT! Otherwise possible recurence cycle
+        }
+        if (sinceTs) {
+          stitOpts.filter = Filter(`lastUpdate > :date`, { date: sinceTs })
+        }
+        const stUpdate = await this._client.query(AFStitek, stitOpts)
+
+        for (const st of stUpdate) {
+          st.skupVybKlic = this._stitekSkupiny.find(ss => ss.kod === st.skupVybKlic?.kod)
+          const found = this._stitky.find(s => s.id === st.id)
+          if (!found) {
+            this._stitky.push(st)
+            continue
+          }
+          Object.assign(found, st)
+        }
+
+        this._lastUpdate = now
+      } finally {
+        this._inflight = undefined
       }
-      Object.assign(found, sk)
-    }
+    })()
 
-    const stitOpts: AFQueryOptions = {
-      limit: NO_LIMIT,
-      detail: ['id', 'kod', 'lastUpdate', 'nazev', 'nazevA', 'nazevB', 'nazevC', 'nazevD', 'poznam', 'popis', 'platiOd', 'platiDo', 'skupVybKlic'],
-      noUpdateStitkyCache: true, // IMPORTANT! Otherwise possible recurence cycle
-    }
-    if (this._lastUpdate) {
-      skupOpts.filter = Filter(`lastUpdate > ':date'`, { date: this._lastUpdate })
-    }
-    const stUpdate = await this._client.query(AFStitek, stitOpts)
-
-    for (const st of stUpdate) {
-      st.skupVybKlic = this._stitekSkupiny.find(ss => ss.kod === st.skupVybKlic?.kod)
-      const found = this._stitky.find(s => s.id === st.id)
-      if (!found) {
-        this._stitky.push(st)
-        continue
-      }
-      Object.assign(found, st)
-    }
+    return this._inflight
   }
 
   public stitkyWithString(
@@ -96,4 +111,13 @@ export class AFStitkyCache {
     }
     return list
   }
+}
+
+// Abra Flexi accepts timestamps in `yyyy-MM-dd'T'HH:mm:ss` (server-local time).
+// formatScalar in AFFilterHelper outputs date-only `yyyy-MM-dd`, which the
+// server rejects for timestamp properties like `lastUpdate`.
+function formatAbraTimestamp(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+    + `T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
 }

--- a/src/abra/AFTypes.ts
+++ b/src/abra/AFTypes.ts
@@ -44,11 +44,40 @@ export enum UpdateStrategy {
 
 export type AFApiFetch = (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>
 
+// Output formats supported by Abra Flexi (URL extension). The `(string & {})`
+// fallback keeps autocomplete on the literals while allowing other extensions
+// (e.g. 'isdocx') without changes to this type.
+export type AFResponseFormat =
+  | 'json'
+  | 'xml'
+  | 'pdf'
+  | 'html'
+  | 'csv'
+  | 'isdoc'
+  | (string & {})
+
+export type AFFileResult = {
+  blob: Blob,
+  contentType: string,
+  filename?: string
+}
+
+export type AFLogLevel = 'none' | 'error' | 'warn' | 'info' | 'debug'
+
+export interface AFLogger {
+  debug(...args: any[]): void
+  info(...args: any[]): void
+  warn(...args: any[]): void
+  error(...args: any[]): void
+}
+
 export type AFApiConfig = {
   url: string,
   company: string,
   fetch?: AFApiFetch,
-  stitkyCacheStrategy?: StitkyCacheStrategy
+  stitkyCacheStrategy?: StitkyCacheStrategy,
+  logger?: AFLogger,
+  logLevel?: AFLogLevel
 }
 
 export type NO_LIMIT_T = 0
@@ -62,7 +91,7 @@ export enum AFQueryDetail {
 
 export type AFNestedDetail = (string | [string, AFNestedDetail])[]
 
-export type AFQueryOptions = { 
+export type AFQueryOptions = {
   detail?: AFNestedDetail | AFQueryDetail,
   filter?: AFFilter,
   limit?: number | NO_LIMIT_T,
@@ -76,14 +105,32 @@ export type AFQueryOptions = {
   noSimpleMode?: boolean,
   noValidityCheck?: boolean,
   noUpdateStitkyCache?: boolean,
-  entityPathPrefix?: string,
   ucetniObdobi?: string,
   koncovyMesicRok?: string,
   pocetMesicu?: number
   date?: string
   currency?: string
 
+  // Parent-entity selectors for nested entities. The resolver in
+  // AFNestedEntityResolver.ts decides which selector applies to which entity.
+  // Example: AFIndividualniCenik uses `adresarId` to scope under /adresar/<id>/
+  // Accepts a numeric id, an id-as-string, or an AFFilter built via ID(...) /
+  // CODE(...) / EXT(...) for selecting the parent by code or external id.
+  adresarId?: number | string | AFFilter
+
   abortController?: AbortController
+}
+
+// Options for non-JSON formats fetched via queryFile / queryFileRaw.
+// Adds report-related parameters that Abra Flexi accepts on file endpoints
+// (e.g. PDF rendered from a named template in a specific language).
+export type AFQueryFileOptions = AFQueryOptions & {
+  // Maps to the `report-name` URL query parameter — name of the print
+  // template/report to use when rendering the file.
+  reportName?: string,
+  // Maps to the `report-lang` URL query parameter — language code for the
+  // report (e.g. 'cs', 'en').
+  reportLang?: string
 }
 
 export type AFURelOptions = {
@@ -123,6 +170,15 @@ export type AFSaveOptions = {
 }
 
 export type AFDeleteOptions = {
+  abortController?: AbortController,
+  // When true, the delete is performed via PUT with `@action: 'delete'` instead
+  // of an HTTP DELETE on /entity/<id>. Required for entities like
+  // AFUzivatelskaVazba where the standard DELETE endpoint is not supported.
+  // The high-level delete() sets this automatically based on the entity class.
+  asUserRelation?: boolean
+}
+
+export type AFActionOptions = {
   abortController?: AbortController
 }
 

--- a/src/abra/AFTypes.ts
+++ b/src/abra/AFTypes.ts
@@ -76,9 +76,12 @@ export type AFQueryOptions = {
   noSimpleMode?: boolean,
   noValidityCheck?: boolean,
   noUpdateStitkyCache?: boolean,
+  entityPathPrefix?: string,
   ucetniObdobi?: string,
   koncovyMesicRok?: string,
   pocetMesicu?: number
+  date?: string
+  currency?: string
 
   abortController?: AbortController
 }
@@ -115,7 +118,8 @@ export type AFURelMinimal = AFEntity & {
 
 export type AFSaveOptions = {
   updateStrategy?: UpdateStrategy,
-  abortController?: AbortController
+  abortController?: AbortController,
+  removeStitky?: boolean
 }
 
 export type AFDeleteOptions = {

--- a/src/generated/entities/AFPriloha.ts
+++ b/src/generated/entities/AFPriloha.ts
@@ -85,7 +85,7 @@ export class AFPriloha extends AFEntity {
   // Událost (db: IdAdrUdalost) - Událost)
   adrUdalost?: AFUdalost | null
   // Obsah (db: ) - Obsah)
-  content?: Buffer | null
+  content?: Uint8Array | null
 
   // Uživatelské vazby (type: VAZBA) - uzivatelske-vazby)
   'uzivatelske-vazby'?: AFUzivatelskaVazba[]


### PR DESCRIPTION
This PR introduces multiple fixes, improvements, and new features across entity handling, error propagation, caching, and file/report support.

## Fix: Entity deletion no longer throws exception
Deleting entities previously always resulted in an exception due to a JSON parsing issue. This has been fixed.
Fixes https://github.com/tomasKavan/abraFlexiClient/issues/6

## Improvement: Error propagation to client
Errors from Abra requests are now properly returned to the user instead of being swallowed.
Closes https://github.com/tomasKavan/abraFlexiClient/issues/12

## Fix: Tags cache
Fixed unnecessary repeated requests, corrected debouncing behavior. Fixed incorrect lastUpdate handling (was treated as date only, but includes time). Added in-flight protection against concurrent requests.

## Fix: New vs existing entity detection (`isNew()`)
Previously, entities with `id` or `kod` were always treated as existing, since the `isNew()` method simply checked for existence of `id` or `kod`.
Now, entities created via `createIdStub` are automatically marked with `isNew = false`. Entities created manually (via `create` method) with `id`/`kod` are treated as new.

## Fix: Creating entity with user relation
Abra does not support creating an entity together with a user relation in a single call. The `abra-flexi` library now throws a descriptive exception suggesting use of a subsequent request.
Closes https://github.com/tomasKavan/abraFlexiClient/issues/9

## Refactor: `delete` and `deleteUserRelation`
Removed `deleteUserRelation` and unified with `delete` method.

## Improvement: `save()` now assigns generated ID
The Abra API returns generated IDs of created entities. This is now properly handled and assigned to the entity.
Closes https://github.com/tomasKavan/abraFlexiClient/issues/8

## Change: refactor entity path prefix
Removed `entityPathPrefix` option. Instead added custom parameters to query nested entities such as `adresarId`.
Makes future extension easier and hides URL structure from the user.

## Improvement: Logging
- No longer logs everything to console by default. Default behavior is silent.
- Setting logLevel enables console logging for that level.
- Supports custom external loggers (e.g., winston) with proper log level handling.

Closes https://github.com/tomasKavan/abraFlexiClient/issues/13

## Improvement: Optional options parameter
API method options parameter is now optional. Previously required passing `{}` (e.g., in `delete` method).

## Feature: Support for non-JSON file downloads
Example
```
// JSON (unchanged)
const items = await client.query(AFFakturaVydana, { filter: ID(42) })

// PDF
const pdf = await client.queryFile(AFFakturaVydana, 'pdf', { filter: ID(42) })
fs.writeFileSync(pdf.filename ?? 'faktura.pdf', Buffer.from(await pdf.blob.arrayBuffer()))

// XML, CSV, etc.
const xml = await client.queryFile(AFFakturaVydana, 'xml', { filter: ID(42) })
const csv = await client.queryFile(AFAdresar, 'csv', { limit: 100 })

// Forward-compatible extensions
const isdocx = await client.queryFile(AFFakturaVydana, 'isdocx', { filter: ID(42) })
```

Closes https://github.com/tomasKavan/abraFlexiClient/issues/15

## Feature: Custom entity reports
Implemented via `queryFile` method. Added `reportName` and `reportLang` parameters.

## Feature: Entity actions
New method: `callEntityAction`.
Example
```
const testInvoice = await this.api.createIdStub(AFFakturaVydana, { id: 2452 })
const response = await this.api.callEntityAction(testInvoice, 'storno')
```
